### PR TITLE
Probably fixes error

### DIFF
--- a/v1/v1.py
+++ b/v1/v1.py
@@ -5,7 +5,7 @@ import uuid
 
 from IPython.core.magic import Magics, cell_magic, magics_class
 
-compiler = '/usr/local/cuda/bin/nvcc'
+compiler = '/usr/local/cuda/bin/nvcc -Wno-deprecated-gpu-targets'
 ext = '.cu'
 
 

--- a/v2/v2.py
+++ b/v2/v2.py
@@ -5,7 +5,7 @@ from IPython.core.magic import Magics, cell_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from common import helper
 
-compiler = '/usr/local/cuda/bin/nvcc'
+compiler = '/usr/local/cuda/bin/nvcc --Wno-deprecated-gpu-targets'
 
 @magics_class
 class NVCCPluginV2(Magics):


### PR DESCRIPTION
found sources: []
nvcc warning : The 'compute_20', 'sm_20', and 'sm_21' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
nvcc fatal   : Don't know what to do with ''