### PR TITLE
Convert TimeitResult object to human readable string

### DIFF
--- a/v1/v1.py
+++ b/v1/v1.py
@@ -28,6 +28,7 @@ class NVCCPlugin(Magics):
             stmt = f"subprocess.check_output(['{file_path}.out'], stderr=subprocess.STDOUT)"
             output = self.shell.run_cell_magic(
                 magic_name="timeit", line="-q -o import subprocess", cell=stmt)
+            output = str(output) # convert TimeitResult object to human readable string
         else:
             output = subprocess.check_output(
                 [file_path + ".out"], stderr=subprocess.STDOUT)

--- a/v2/v2.py
+++ b/v2/v2.py
@@ -37,6 +37,7 @@ class NVCCPluginV2(Magics):
             stmt = f"subprocess.check_output(['{self.out}'], stderr=subprocess.STDOUT)"
             output = self.shell.run_cell_magic(
                 magic_name="timeit", line="-q -o import subprocess", cell=stmt)
+            output = str(output) # convert TimeitResult object to human readable string
         else:
             output = subprocess.check_output(
                 [self.out], stderr=subprocess.STDOUT)


### PR DESCRIPTION
Using the timeit option ("-t") throws an AttributeError in the helper.print_out function:

```python
[<ipython-input-3-7685182fc153>](https://localhost:8080/#) in <cell line: 1>()
----> 1 get_ipython().run_cell_magic('cu', '-t', '#include <iostream>\nint\tmain()\n{\n\tstd::cout << "It works!\\n";\n\treturn 0;\n}\n')

5 frames
<decorator-gen-118> in cu(self, line, cell)

[/usr/local/lib/python3.10/dist-packages/common/helper.py](https://localhost:8080/#) in print_out(out)
     10 
     11 def print_out(out: str):
---> 12     for l in out.split('\n'):
     13         print(l)

AttributeError: 'TimeitResult' object has no attribute 'split'
```

This happens because [this line](https://github.com/andreinechaev/nvcc4jupyter/blob/98566ce171234c1c6d440b08b91c830739327799/v1/v1.py#L29) in v1.py and [this line](https://github.com/andreinechaev/nvcc4jupyter/blob/98566ce171234c1c6d440b08b91c830739327799/v2/v2.py#L37) in v2.py is a [TimeitResult object](https://github.com/ipython/ipython/blob/b5bf8f1525508eee3bb74d84e5e99c9486e3cd2c/IPython/core/magics/execution.py#L72) which can be turned into a human readable string using its __str__ dunder method.









