### PR TITLE
Add option to use NVIDIA Nsight Compute CLI profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ V2 brings support of multiple source and header files.
 %%cuda_run
 # This line just to bypass an exeption and can contain any text
 ```
+
+- To profile your CUDA kernels using NVIDIA Nsight Compute CLI profiler you need to run
+```
+%%cu --profile
+```
+- You can add options to the profiler. Keep in mind that any argument after "--profiler-args" will be considered as a profiler argument. For example, to select which sections to collect metrics for you need to run
+```
+%%cu --profile --profiler-args --section SpeedOfLight --section MemoryWorkloadAnalysis --section Occupancy
+```

--- a/common/helper.py
+++ b/common/helper.py
@@ -3,8 +3,25 @@ import argparse
 
 def get_argparser():
     parser = argparse.ArgumentParser(description='NVCCPlugin params')
-    parser.add_argument("-t", "--timeit", action='store_true',
-                        help='flag to return timeit result instead of stdout')
+    parser.add_argument(
+        '-t', 
+        '--timeit',
+        action='store_true',
+        help='If set, returns the output of the "timeit" built-in ipython magic instead of stdout.',
+    )
+    parser.add_argument(
+        '-p', 
+        '--profile', 
+        action='store_true',
+        help='If set, runs the nvidia nsight compute profiler. Has no effect if used with --timeit.',
+    )
+    parser.add_argument(
+        '-a'
+        '--profiler-args',
+        type=str,
+        default='',
+        help='Extra options that can be passed to the nvidia nsight compute profiler.',
+    )
     return parser
 
 

--- a/common/helper.py
+++ b/common/helper.py
@@ -19,8 +19,10 @@ def get_argparser():
         '-a',
         '--profiler-args',
         type=str,
-        default='',
-        help='Extra options that can be passed to the nvidia nsight compute profiler.',
+        nargs=argparse.REMAINDER,
+        default=[],
+        help='Extra options that can be passed to the nvidia nsight compute profiler. '
+             'Must be the last option given to the argument parser so you can pass arguments with dashes.',
     )
     return parser
 

--- a/common/helper.py
+++ b/common/helper.py
@@ -16,7 +16,7 @@ def get_argparser():
         help='If set, runs the nvidia nsight compute profiler. Has no effect if used with --timeit.',
     )
     parser.add_argument(
-        '-a'
+        '-a',
         '--profiler-args',
         type=str,
         default='',

--- a/v1/v1.py
+++ b/v1/v1.py
@@ -24,7 +24,7 @@ class NVCCPlugin(Magics):
         subprocess.check_output(
             [compiler, file_path + ext, "-o", file_path + ".out", '-Wno-deprecated-gpu-targets'], stderr=subprocess.STDOUT)
 
-    def run(self, file_path, timeit=False, profile=False, profiler_args=""):
+    def run(self, file_path, timeit=False, profile=False, profiler_args=[]):
         if timeit:
             stmt = f"subprocess.check_output(['{file_path}.out'], stderr=subprocess.STDOUT)"
             output = self.shell.run_cell_magic(
@@ -32,7 +32,7 @@ class NVCCPlugin(Magics):
         else:
             run_args = []
             if profile:
-                run_args.extend([profiler] + profiler_args.split())
+                run_args.extend([profiler] + profiler_args)
             run_args.append(file_path + ".out")
             output = subprocess.check_output(run_args, stderr=subprocess.STDOUT)
             output = output.decode('utf8')

--- a/v1/v1.py
+++ b/v1/v1.py
@@ -24,7 +24,7 @@ class NVCCPlugin(Magics):
         subprocess.check_output(
             [compiler, file_path + ext, "-o", file_path + ".out", '-Wno-deprecated-gpu-targets'], stderr=subprocess.STDOUT)
 
-    def run(self, file_path, timeit=False, profile=True):
+    def run(self, file_path, timeit=False, profile=False, profiler_args=""):
         if timeit:
             stmt = f"subprocess.check_output(['{file_path}.out'], stderr=subprocess.STDOUT)"
             output = self.shell.run_cell_magic(
@@ -32,7 +32,7 @@ class NVCCPlugin(Magics):
         else:
             run_args = []
             if profile:
-                run_args.extend([profiler, "-o", "profile"])
+                run_args.extend([profiler] + profiler_args.split())
             run_args.append(file_path + ".out")
             output = subprocess.check_output(run_args, stderr=subprocess.STDOUT)
             output = output.decode('utf8')
@@ -54,7 +54,7 @@ class NVCCPlugin(Magics):
                 f.write(cell)
             try:
                 self.compile(file_path)
-                output = self.run(file_path, timeit=args.timeit)
+                output = self.run(file_path, timeit=args.timeit, profile=args.profile, profiler_args=args.profiler_args)
             except subprocess.CalledProcessError as e:
                 helper.print_out(e.output.decode("utf8"))
                 output = None


### PR DESCRIPTION
This allows using the NVIDIA Nsight profiler (its output will be printed in the cell output with the "==PROF==" prefix) with the %%cu, %%cuda, and %%cuda_run magics. There is also an option "--profiler-args" through which you can pass an arbitrary number of arguments to the profiler (for example, if you want it to collect information only from specific sections; there is an example in the updated README.md).